### PR TITLE
Automate build round downloads

### DIFF
--- a/.github/workflows/fetch_builds.yml
+++ b/.github/workflows/fetch_builds.yml
@@ -21,12 +21,16 @@ jobs:
         run: |
           pip install requests
 
-      - name: Fetch builds and update file
+      - name: Fetch builds index
         run: |
           python3 fetch_builds.py
+
+      - name: Download new build rounds
+        run: |
+          python3 builds-download/scrape-builds.py
 
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Update builds.json from Supabase
-          file_pattern: builds.json
+          commit_message: Update build data from Supabase
+          file_pattern: 'builds.json builds-download/build_rounds_data/*.json'


### PR DESCRIPTION
## Summary
- update workflow to download build rounds with index
- add deduplication logic to `scrape-builds.py`
- compute paths relative to script for correctness

## Testing
- `python3 -m py_compile builds-download/scrape-builds.py`
- `python3 -m py_compile fetch_builds.py`


------
https://chatgpt.com/codex/tasks/task_e_683fd3361640832daead570abc6e2211