### PR TITLE
Add SQLite database generation

### DIFF
--- a/.github/workflows/fetch_builds.yml
+++ b/.github/workflows/fetch_builds.yml
@@ -33,4 +33,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Update build data from Supabase
-          file_pattern: 'builds.json builds-download/build_rounds_data/*.json'
+          file_pattern: 'builds.json builds-download/build_rounds_data/*.json builds.db'

--- a/fetch_builds.py
+++ b/fetch_builds.py
@@ -1,5 +1,8 @@
 import requests
 import json
+import sqlite3
+import os
+from glob import glob
 
 API_URL = "https://qkdvetofbsoynkfprlos.supabase.co/rest/v1/rpc/filter_builds_advanced"
 API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFrZHZldG9mYnNveW5rZnBybG9zIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDU3Mjc0NDEsImV4cCI6MjA2MTMwMzQ0MX0.Moy2MzlEQ0w1cqvnMs3qAV6Mzdm8R1v_YSo7Zw93mG8"
@@ -10,6 +13,10 @@ HEADERS = {
 }
 
 LIMIT = 1000
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+ROUND_DATA_DIR = os.path.join(BASE_DIR, "builds-download", "build_rounds_data")
+DB_PATH = os.path.join(BASE_DIR, "builds.db")
 
 def fetch_all_builds():
     all_builds = []
@@ -32,8 +39,45 @@ def fetch_all_builds():
 
     return all_builds
 
+
+def create_sqlite_database(builds):
+    """Create or update the SQLite database with build index and round data."""
+    conn = sqlite3.connect(DB_PATH)
+    cur = conn.cursor()
+
+    # Tables: one for the index, one for per-build round data
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS builds_index (id TEXT PRIMARY KEY, data TEXT)"
+    )
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS build_rounds (build_id TEXT PRIMARY KEY, data TEXT)"
+    )
+    conn.commit()
+
+    # Insert index data
+    rows = [(b.get("id"), json.dumps(b, ensure_ascii=False)) for b in builds]
+    cur.executemany(
+        "INSERT OR REPLACE INTO builds_index (id, data) VALUES (?, ?)", rows
+    )
+
+    # Insert round data from json files if available
+    if os.path.isdir(ROUND_DATA_DIR):
+        for path in glob(os.path.join(ROUND_DATA_DIR, "*.json")):
+            build_id = os.path.splitext(os.path.basename(path))[0]
+            with open(path, "r", encoding="utf-8") as f:
+                round_data = json.load(f)
+            cur.execute(
+                "INSERT OR REPLACE INTO build_rounds (build_id, data) VALUES (?, ?)",
+                (build_id, json.dumps(round_data, ensure_ascii=False)),
+            )
+
+    conn.commit()
+    conn.close()
+
 if __name__ == "__main__":
     builds = fetch_all_builds()
     with open("builds.json", "w", encoding="utf-8") as f:
         json.dump(builds, f, indent=2, ensure_ascii=False)
     print(f"Wrote {len(builds)} builds to builds.json")
+    create_sqlite_database(builds)
+    print(f"SQLite database updated at {DB_PATH}")


### PR DESCRIPTION
## Summary
- extend fetch_builds.py to create a SQLite database
- update workflow to commit the new DB file

## Testing
- `python3 -m py_compile fetch_builds.py`
- `python3 fetch_builds.py`

------
https://chatgpt.com/codex/tasks/task_e_68794418e518832d87363474c9446e5f